### PR TITLE
added goback after stoploading

### DIFF
--- a/components/BrowserHandler.js
+++ b/components/BrowserHandler.js
@@ -30,6 +30,7 @@ export default BrowserHandler = (props) => {
 
         if (!url.includes(baseURL) && !url.includes("judopay")) {
             WEBVIEW_REF.current.stopLoading();
+            WEBVIEW_REF.current.goBack();
             const supported = await Linking.canOpenURL(url);
             if (supported) {
                 await Linking.openURL(url);


### PR DESCRIPTION
This will take the user back to the previous screen after the zen desk loading has started. This was causing the user to have to press back again after exiting the chat.